### PR TITLE
Use modern CMake's target_* functions to set compiler flags/features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,6 @@ project(Bifrost)
 # Can be replaced with a larger and appropriate number (a power of 2). Actual k-mer size is MAX_KMER_SIZE-1.
 set(MAX_KMER_SIZE "32")
 
-set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} "-std=c11 -march=native -DXXH_NAMESPACE=BIFROST_HASH_")
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++11 -march=native -DXXH_NAMESPACE=BIFROST_HASH_")
-
 #set_property(SOURCE xxhash.c APPEND_STRING PROPERTY COMPILE_FLAGS " -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef")
 set_property(SOURCE BlockedBloomFilter.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " -funroll-loops")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.12)
 
 project(Bifrost)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,8 @@ file(GLOB headers *.h *.hpp *.hh *.tcc)
 list(REMOVE_ITEM sources Bifrost.cpp)
 
 add_definitions(-DMAX_KMER_SIZE=${MAX_KMER_SIZE})
+set(BIFROST_COMPILER_FLAGS "-march=native")
+set(BIFROST_COMPILER_DEFINITIONS "-DXXH_NAMESPACE=BIFROST_HASH_")
 
 add_library(bifrost_static STATIC ${sources} ${headers})
 add_library(bifrost_dynamic SHARED ${sources} ${headers})
@@ -13,6 +15,15 @@ set_target_properties(bifrost_dynamic PROPERTIES OUTPUT_NAME "bifrost")
 
 target_include_directories(bifrost_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(bifrost_dynamic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_compile_features(bifrost_static PUBLIC cxx_std_11)
+target_compile_features(bifrost_dynamic PUBLIC cxx_std_11)
+
+target_compile_options(bifrost_static PUBLIC "${BIFROST_COMPILER_FLAGS}")
+target_compile_options(bifrost_dynamic PUBLIC "${BIFROST_COMPILER_FLAGS}")
+
+target_compile_definitions(bifrost_static PRIVATE "${BIFROST_COMPILER_DEFINITIONS}")
+target_compile_definitions(bifrost_dynamic PRIVATE "${BIFROST_COMPILER_DEFINITIONS}")
 
 add_executable(Bifrost Bifrost.cpp)
 
@@ -56,6 +67,9 @@ else()
 endif(ZLIB_FOUND)
 
 target_link_libraries(Bifrost bifrost_dynamic)
+target_compile_features(Bifrost PUBLIC cxx_std_11)
+target_compile_options(Bifrost PUBLIC "${BIFROST_COMPILER_FLAGS}")
+target_compile_definitions(Bifrost PRIVATE "${BIFROST_COMPILER_DEFINITIONS}")
 
 install(TARGETS Bifrost DESTINATION bin)
 install(TARGETS bifrost_dynamic DESTINATION lib)


### PR DESCRIPTION
Hi all,

Thank you for this great piece of software, it's blazingly fast and memory efficient! The past few days I have been playing around a bit with the API, and trying to integrate it in one of my projects. 

In my own C++ projects, I usually include third party depencies as git submodules in a `vendor/` directory. Then in my own CMakeLists.txt files, I can call `add_subdirectory` on those third party dependencies, and all their targets will be available in my own CMakeList.txt too (makes it easy to link them, and configure all include directories etc.)

I did the same thing with Bifrost, however, one of my executables was segfaulting, even though it was a very tiny toy example that hardly did anything. After some debugging, I found that my executable missed the `-march=native` compiler flag, and therefore the instruction sets of bifrost_static and my executable mismatched, resulting in stack corruption.

The new target_* based API introduced in CMake 3 is supposed to better deal with these kinds of situations. In this pull request I changed the CMakeLists.txt a bit to make use of this new API. This makes it easier to include Bifrost in other (CMake based) projects, by simply including Bifrost using `add_directory` and linking to `bifrost_static` or `bifrost_dynamic`, and ensures that the required compiler flags get propagated to the linked executables too.

I'll admit, I've only minimally changed it, until it fixed my problem 😬  I've not checked the options you seem to use for profiling etc. Anyway hope it's a useful starting point. I've found this guide on modern Cmake helpful: https://cliutils.gitlab.io/modern-cmake/