### PR TITLE
Fix compilation error with custom unitig data

### DIFF
--- a/src/DataStorage.hpp
+++ b/src/DataStorage.hpp
@@ -67,6 +67,8 @@ class DataStorage {
 
         inline size_t getNbColors() const { return color_names.size(); }
 
+        inline vector<string> const& getColorNames() const { return color_names; }
+
         size_t getUnitigColorsSize(const size_t nb_threads = 1) const;
 
         uint64_t getHash(const UnitigColorMap<U>& um) const;

--- a/src/DataStorage.tcc
+++ b/src/DataStorage.tcc
@@ -78,7 +78,7 @@ DataStorage<U>::DataStorage(const DataStorage& o) : color_sets(nullptr), shared_
 
         unitig_cs_link = new atomic<uint64_t>[sz_link];
 
-        for (size_t i = 0; i != sz_link; ++i) unitig_cs_link[i] = o.sz_link[i].load();
+        for (size_t i = 0; i != sz_link; ++i) unitig_cs_link[i] = o.unitig_cs_link[i].load();
     }
 
     if ((o.data != nullptr) && (o.sz_cs != 0)){


### PR DESCRIPTION
For my Python bindings I have custom type for unitig data (instead of void), but when I tried to compile with a custom unitig data type it gave an error in `DataStorage.tcc`

And this commit accidentally also includes another function to obtain the color_names from DataStorage which I found useful.