### PR TITLE
Enable from source compilation through pipy

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sudo apt-get install build-essential cmake zlib1g-dev
   brew install brewsci/bio/bifrost
   ```
 
-* From [Bioconda](https://bioconda.github.io) (Bifrost v1.0.3, Linux only):
+* From [Bioconda](https://bioconda.github.io) (Bifrost v1.0.3, Linux only, compiled to generic x86-64 architecture and does not include advanced SSE and AVX instructions):
 
   ```
   conda -c bioconda bifrost
@@ -96,6 +96,19 @@ sudo apt-get install build-essential cmake zlib1g-dev
   * Bifrost uses AVX2 instructions during graph construction which can be disabled by adding the option `-DENABLE_AVX2=OFF` to the `cmake` command.
 
   If you encounter any problem during the installation, see the [Troubleshooting](#troubleshooting) section.
+
+* From source through pypi (Bifrost v1.0.4)
+
+```
+pip install bifrost-src
+```
+
+* From source through conda (Bifrost v1.0.4)
+
+```
+conda env create -n bifrost -f environment.yml
+```
+
 
 ### Large *k*-mers
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+dependencies:
+  - python=3.6
+  - pip=20.1.1
+  - zlib=1.2.11
+  - pip:
+    - bifrost-src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from skbuild import setup 
+
+setup(name='bifrost-src',
+      description='',
+      version='1.0.4',
+      data_files=[
+          ('.', ['setup.py'])
+      ],
+      )
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
     message(FATAL_ERROR "zlib not found. Required for to output files")
 endif(ZLIB_FOUND)
 
-target_link_libraries(Bifrost bifrost_dynamic)
+target_link_libraries(Bifrost bifrost_static)
 
 install(TARGETS Bifrost DESTINATION bin)
 install(TARGETS bifrost_dynamic DESTINATION lib)


### PR DESCRIPTION
This PR allows the packaging of the bifrost source code into python source distributions and wheels. I have deployed this code to pypi under the project name `bifrost-src`. 