### PR TITLE
Fix memory error in multithreaded query

### DIFF
--- a/src/Search.tcc
+++ b/src/Search.tcc
@@ -1215,7 +1215,7 @@ bool CompactedDBG<U, G>::search(const vector<string>& query_filenames, const str
 
                     [&]{
 
-                        char* buffer_res = new char[nb_threads];
+                        char* buffer_res = new char[thread_seq_buf_sz];
 
                         vector<string> buffers_seq;
                         vector<string> buffers_name;


### PR DESCRIPTION
Apparently, the `buffer_res` was created with the number of threads in the multithreaded query.
In the single-threaded query it is created with `thread_seq_buf_sz`, so I used that same variable here and it seems to work.

Fixes #45